### PR TITLE
Correct call to promptForKeystorePassword for keystore password confirmation

### DIFF
--- a/banditoth-VSCode-MAUI-Archive/Commands/androidCommands.js
+++ b/banditoth-VSCode-MAUI-Archive/Commands/androidCommands.js
@@ -113,7 +113,7 @@ async function generateCodeSigningKey() {
         return;
     }
 
-    const keyPassword = await androidFeatures.promptForKeyPassword();
+    const keyPassword = await androidFeatures.promptForKeystorePassword();
     if (!keyPassword || keyPassword.length < 6) {
         vscode.window.showWarningMessage('Key password must be at least 6 characters.');
         return;


### PR DESCRIPTION
I think this is the correct fix! Seems to be a small error in the method name.

Fixes #1