### PR TITLE
Fix for #15 and #13: duplicated keystore file path in publishing Android app

### DIFF
--- a/banditoth-VSCode-MAUI-Archive/Platforms/androidFeatures.js
+++ b/banditoth-VSCode-MAUI-Archive/Platforms/androidFeatures.js
@@ -126,5 +126,5 @@ async function showPickerForKeystore() {
         placeHolder: 'Select a keystore'
     });
 
-    return selectedKeystore ? path.join(androidKeystoreListPath, selectedKeystore) : null;
+    return selectedKeystore;
 }


### PR DESCRIPTION
Fix for #15 and #13.