### PR TITLE
Update default .NET target to net10.0

### DIFF
--- a/banditoth-VSCode-MAUI-Archive/README.md
+++ b/banditoth-VSCode-MAUI-Archive/README.md
@@ -88,7 +88,7 @@ Opens the settings for the MAUI Archive extension, allowing users to configure p
 | Setting name | Description | Default Value |
 | --- | --- | --- |
 | Build configuration | You can specify a custom build configuration when publishing your apps | 'Release' |
-| Dotnet version | You can specify a custom dotnet version like net7.0 when publishing your apps | 'net9.0' |
+| Dotnet version | You can specify a custom dotnet version like net7.0 when publishing your apps | 'net10.0' |
 | Enable Solution file format | When searching the workspace for .csproj files, this setting enabled the discovery of .sln files aswell | 'false' |
 | Android keystore directory | You can specify a custom directory path to your Android keystore files | - |
 | Android key tool path | Set a custom directory where your Android keystores are located at. Leave blank for default. | - |
@@ -115,4 +115,3 @@ For major changes, please open a discussion first.
 ### Acknowledgements
 
 Thanks to Gerald Versluis and James Montemagno for spreading the word about this tool.
-

--- a/banditoth-VSCode-MAUI-Archive/package.json
+++ b/banditoth-VSCode-MAUI-Archive/package.json
@@ -100,7 +100,7 @@
         },
         "VSCode-MAUI-Archive.dotnetVersion": {
           "type": "string",
-          "default": "net9.0",
+          "default": "net10.0",
           "description": "Determines dotnet version to use"
         },
         "VSCode-MAUI-Archive.enableSolutionFileFormat": {


### PR DESCRIPTION
### Motivation
- Enable compatibility with .NET 10 by updating the extension's default target framework and documentation.

### Description
- Change the default `VSCode-MAUI-Archive.dotnetVersion` value in `package.json` from `net9.0` to `net10.0`.
- Update the README settings table to show the new default `net10.0`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696946ae25248321b8b94864f165896a)